### PR TITLE
better GetConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Go Enigma

--- a/main.go
+++ b/main.go
@@ -13,8 +13,7 @@ import (
 )
 
 func main() {
-	config := utils.GetConfig()
-	bot, err := discord.New("Bot " + config.Token)
+	bot, err := discord.New("Bot " + utils.GetConfig("token"))
 
 	if err != nil {
 		fmt.Println("error logging in,", err)

--- a/utils/config.go
+++ b/utils/config.go
@@ -5,15 +5,24 @@ import (
 	"io/ioutil"
 )
 
-// Config : Configuration from config.json
-type Config struct {
-	Token string `json:"token"`
+var conf map[string]string
+
+func GetConfig(key string) string {
+	val, ok := conf[key]
+	if !ok {
+		return ""
+	} else {
+		return val
+	}
 }
 
-// GetConfig returns config from JSON
-func GetConfig() (data Config) {
-	file, _ := ioutil.ReadFile("config.json")
-	data = Config{}
-	_ = json.Unmarshal([]byte(file), &data)
-	return
+func init() {
+	data, err := ioutil.ReadFile("config.json")
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(data, &conf)
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
Better GetConfig, it limits config to only store string values but it's worth the benifits you shouldn't even need anything other than strings for a config, first it caches the config on startup so no need to read file everytime you need a key, makes it faster to access it on commands that needs a config eg an api key, and no need to add keys on the struct.